### PR TITLE
fix: swap lat/lon mapping in floods process_nc

### DIFF
--- a/base/datasets/ewds_floods.py
+++ b/base/datasets/ewds_floods.py
@@ -95,8 +95,8 @@ def process_nc(ncfilepath, glofas_thresold):
     # rename columns latbin, lonbin with lat lon
     df.rename(
         columns={
-            "latbin": "LONGITUDE",
-            "lonbin": "LATITUDE",
+            "latbin": "LATITUDE",
+            "lonbin": "LONGITUDE",
             "valid_time": "EVENT_DATE",
             "count": "COUNT",
         },


### PR DESCRIPTION
latbin was incorrectly renamed to LONGITUDE and lonbin to LATITUDE, causing flood event coordinates to be swapped in all processed parquets.