### PR TITLE
climate: use fixed reference period (year <= 2020) for normalization

### DIFF
--- a/climate/shared.py
+++ b/climate/shared.py
@@ -115,13 +115,12 @@ class NormalizationMixin:
         indicator_config: dict,
         start_year: int,
         normalize_raw_col: bool = True,
+        reference_cutoff_year: int = 2020,
     ) -> pd.DataFrame:
         # load transformation config
         transformation_func = self._TRANSFORMATION_MAP().get(indicator_config.get("transformation"))
         # load normalization limit
         quantile_normalization_limit = indicator_config.get("normalization_quantile")
-
-        kwargs = quantile_normalization_limit if quantile_normalization_limit else {}
 
         # Fallback to identity if no transformation
         func = transformation_func if transformation_func else lambda x: x
@@ -132,9 +131,26 @@ class NormalizationMixin:
         else:
             norm_col = composite_id
 
-        # Apply transformation and normalize
-        df_indicator[f"{composite_id}"] = winsorization_normalization(
-            df_indicator[norm_col].apply(func), **kwargs
+        # Apply transformation
+        series = df_indicator[norm_col].apply(func)
+
+        # Fixed reference period: compute winsorization limits on data
+        # up to and including `reference_cutoff_year` (default 2020), so
+        # historical scores stay stable as new quarters are added.
+        # Same convention as Deprivation.normalize in
+        # vulnerability/socioeconomic/deprivation.py.
+        ref = series[df_indicator["year"] <= reference_cutoff_year]
+
+        if quantile_normalization_limit is None:
+            minv, maxv = ref.min(), ref.max()
+        else:
+            q = quantile_normalization_limit["limits"]
+            ignore_zeroes = quantile_normalization_limit.get("ignore_zeroes_limit", False)
+            src = ref[ref != 0] if ignore_zeroes else ref
+            minv, maxv = np.nanquantile(src, q)
+
+        df_indicator[composite_id] = winsorization_normalization(
+            series, limits=(minv, maxv), fixed_limits=True,
         )
 
         # Set index

--- a/climate/shared.py
+++ b/climate/shared.py
@@ -144,10 +144,7 @@ class NormalizationMixin:
         if quantile_normalization_limit is None:
             minv, maxv = ref.min(), ref.max()
         else:
-            q = quantile_normalization_limit["limits"]
-            ignore_zeroes = quantile_normalization_limit.get("ignore_zeroes_limit", False)
-            src = ref[ref != 0] if ignore_zeroes else ref
-            minv, maxv = np.nanquantile(src, q)
+            minv, maxv = np.nanquantile(ref, quantile_normalization_limit["limits"])
 
         df_indicator[composite_id] = winsorization_normalization(
             series, limits=(minv, maxv), fixed_limits=True,


### PR DESCRIPTION
Compute winsorization quantiles and min/max in NormalizationMixin.climate_normalize on the year <= reference_cutoff_year slice (default 2020), then apply the frozen limits to the full series via fixed_limits=True. Mirrors the convention already used in vulnerability/socioeconomic/deprivation.py.

This stabilizes historical climate scores across releases: previously the quantiles/min/max were recomputed over the full series each quarter, shifting all past scores. With a fixed reference period, only post-2020 quarters can move (and are clipped to the baseline limits).

The change lives in the shared mixin, so it covers every climate indicator (current/accumulated/longterm × cyclones, drought, floods, heatwave, heavy_precipitation, wildfires) without per-indicator edits or config changes.